### PR TITLE
Remove Login Artwork

### DIFF
--- a/midnight.css
+++ b/midnight.css
@@ -183,6 +183,12 @@
 	width: 340px;
 }
 
+/* remove login artwork */
+svg.artwork-L5TAwQ {
+	display: none !important;
+	visibility: hidden !important;
+}
+
 /* add margins */
 .base-2jDfDU /* outside edges */ {
 	padding: 0px 10px 10px 0;


### PR DESCRIPTION
It looks bad, especially with this theme. Using no login background looks better:

![Discord_omPh8oYlk5](https://user-images.githubusercontent.com/65787561/227736111-0df8ab4b-e489-4611-b2f1-0306e36bc771.png)
