### PR TITLE
Improve Discord Notice

### DIFF
--- a/midnight-classic.css
+++ b/midnight-classic.css
@@ -176,6 +176,16 @@
 	border-radius: 0 !important;
 }
 
+/* improve notice */
+.notice-2HEN-u {
+	border-radius: var(--roundness);
+	margin-bottom: 10px;
+	box-shadow: none !important;
+}
+.button-1iHNQ2 { /* make notice button rounded */
+	border-radius: var(--roundness);
+}
+
 /* hide scrollbars */
 .scroller-2LSbBU::-webkit-scrollbar-thumb {
 	visibility: hidden;


### PR DESCRIPTION
Makes the notifications/messages at the top of Discord floating, have no shadow and be rounded.

#### New
![image](https://user-images.githubusercontent.com/65787561/227780845-e8ff549d-bd6e-4f8e-912b-ea6a71810552.png)

#### Old
![image](https://user-images.githubusercontent.com/65787561/227780869-8b2a7b98-6d77-4953-8e10-915d14409084.png)
