### PR TITLE
Make emoji selector darker for improved consistency

### DIFF
--- a/midnight.css
+++ b/midnight.css
@@ -145,6 +145,11 @@
 	overflow: visible;
 }
 
+/* make emoji selector darker for improved consistency */
+.sprite-2lxwfc {
+	filter: grayscale(100%) brightness(70%) !important;
+}
+
 /* add rounded corners */
 .container-2cd8Mz /* homepage */,
 .content-1SgpWY .sidebar-1tnWFu /* server list back */,

--- a/midnight.css
+++ b/midnight.css
@@ -146,7 +146,7 @@
 }
 
 /* make emoji selector darker for improved consistency */
-.sprite-2lxwfc {
+.sprite-2lxwfc:not([style*="scale(1.1"]) {
 	filter: grayscale(100%) brightness(70%) !important;
 }
 


### PR DESCRIPTION
I could not figure out how to make it perfect (`#39404D`), but it's better than the default.

![image](https://user-images.githubusercontent.com/65787561/227783818-1f9da23a-ba86-4069-90db-d7a2a962bacf.png) ![image](https://user-images.githubusercontent.com/65787561/227783869-f853a82d-74d6-4996-8735-1bbd9c348d27.png)
