### PR TITLE
fixed missing padding-top in serverlist

### DIFF
--- a/midnight.css
+++ b/midnight.css
@@ -240,7 +240,7 @@ a[href="https://support.discord.com"] /* hide help */
 .guilds__2b93a {
 	background: var(--bg-4);
 	border-radius: var(--roundness);
-	margin: 0 var(--spacing) var(--spacing) var(--spacing);
+	margin: var(--spacing);
 }
 .guilds__2b93a.hidden__7c832 {
 	margin: 0;


### PR DESCRIPTION
i noticed this issue only recently. the serverlist misses its top padding, glueing the container to the top of the window, unlike all other borders of this or any other container of the app. 

|before|after|
|---|---|
|![image](https://github.com/refact0r/midnight-discord/assets/18621898/ff18de59-4afc-4255-b4fe-d5c1c111126d)|![image](https://github.com/refact0r/midnight-discord/assets/18621898/ead38e82-1285-4fdf-98f0-cf1232b43b24)|

*the blue strip at the top in the "before" is my desktop background, to show the glue to window border*

Disclaimer: I'm using the theme in vencord, not betterdiscord. I have not checked if this issue arises in betterdiscord too. if this is an issue for me / vencord only, and not in betterdiscord, feel free to deny the PR. otherwise, i'd be happy about a merge :) 