### PR TITLE
Fix OP tag incorrectly coloured

### DIFF
--- a/midnight.css
+++ b/midnight.css
@@ -170,6 +170,7 @@ path[fill='rgba(35, 165, 90, 1)'] {
 .theme-dark .button__57d93, .theme-light .button__57d93 /* notice banner button */,
 .interactive:hover /* mention hover */ {
 	color: var(--text-0);
+	background-color: var(--accent-3);
 }
 .theme-dark .button__57d93, .theme-light .button__57d93 /* notice banner button */ {
 	border-color: var(--text-0);

--- a/midnight.css
+++ b/midnight.css
@@ -170,6 +170,8 @@ path[fill='rgba(35, 165, 90, 1)'] {
 .theme-dark .button__57d93, .theme-light .button__57d93 /* notice banner button */,
 .interactive:hover /* mention hover */ {
 	color: var(--text-0);
+}
+.botTagRegular_c89c9a {
 	background-color: var(--accent-3);
 }
 .theme-dark .button__57d93, .theme-light .button__57d93 /* notice banner button */ {


### PR DESCRIPTION
Before:
![image](https://github.com/refact0r/midnight-discord/assets/70151481/38c12b4c-d519-4dc3-ab75-395cf5facd1a)
After:
![image](https://github.com/refact0r/midnight-discord/assets/70151481/d43d0a0b-9528-49d9-9068-13b51bc72adf)
