### PR TITLE
Update midnight-nord.theme.css

### DIFF
--- a/flavors/midnight-nord.theme.css
+++ b/flavors/midnight-nord.theme.css
@@ -38,9 +38,9 @@
 	--text-0: #2e3440; /* text on colored elements */
 	--text-1: #eceff4; /* other normally white text */
 	--text-2: #e5e9f0; /* headings and important text */
-	--text-3: #d9dee8; /* normal text */
-	--text-4: #a0a3a7; /* icon buttons and channels */
-	--text-5: #65686c; /* muted channels/chats and timestamps */
+	--text-3: #ECEFF4; /* normal text */
+	--text-4: #D8DEE9; /* icon buttons and channels */
+	--text-5: #434C5E; /* muted channels/chats and timestamps */
 
 	/* background and dark colors */
 	--bg-1: #434c5e; /* dark buttons when clicked */

--- a/flavors/midnight-nord.theme.css
+++ b/flavors/midnight-nord.theme.css
@@ -39,8 +39,8 @@
 	--text-1: #eceff4; /* other normally white text */
 	--text-2: #e5e9f0; /* headings and important text */
 	--text-3: #d9dee8; /* normal text */
-	--text-4: #c4c9d4; /* icon buttons and channels */
-	--text-5: #acb4c3; /* muted channels/chats and timestamps */
+	--text-4: #a0a3a7; /* icon buttons and channels */
+	--text-5: #65686c; /* muted channels/chats and timestamps */
 
 	/* background and dark colors */
 	--bg-1: #434c5e; /* dark buttons when clicked */

--- a/flavors/midnight-nord.theme.css
+++ b/flavors/midnight-nord.theme.css
@@ -39,7 +39,7 @@
 	--text-1: #eceff4; /* other normally white text */
 	--text-2: #e5e9f0; /* headings and important text */
 	--text-3: #ECEFF4; /* normal text */
-	--text-4: #D8DEE9; /* icon buttons and channels */
+	--text-4: #93a4c2; /* icon buttons and channels */
 	--text-5: #434C5E; /* muted channels/chats and timestamps */
 
 	/* background and dark colors */


### PR DESCRIPTION
Make the muted channel/category color look nicer also the unread messages channel color looks better.
More visable diffrences in the colors
new:
![Screenshot 2024-03-18 14 56 47](https://github.com/refact0r/midnight-discord/assets/86129872/838d0f3b-75f7-4c75-b229-1d7229a5d704)
Old:
![Screenshot 2024-03-18 14 57 23](https://github.com/refact0r/midnight-discord/assets/86129872/28ea9043-ca76-4e18-9b2b-d594196d4eba)
