### PR TITLE
Replace GitHub pages links with githubraw links

### DIFF
--- a/flavors/midnight-amaryllis.theme.css
+++ b/flavors/midnight-amaryllis.theme.css
@@ -12,7 +12,13 @@
 
 /* IMPORTANT: make sure to enable dark mode in discord settings for the theme to apply properly!!! */
 
-@import url('https://refact0r.github.io/midnight-discord/midnight.css');
+/*
+links:
+prod: https://cdn.githubraw.com/refact0r/midnight-discord/master/midnight.css
+dev (faster reflected changes): https://githubraw.com/refact0r/midnight-discord/master/midnight.css
+*/
+
+@import url('https://cdn.githubraw.com/refact0r/midnight-discord/master/midnight.css');
 
 @import url('https://api.fontshare.com/v2/css?f[]=chillax@400&display=swap');
 

--- a/flavors/midnight-biscuit.theme.css
+++ b/flavors/midnight-biscuit.theme.css
@@ -12,7 +12,13 @@
 
 /* IMPORTANT: make sure to enable dark mode in discord settings for the theme to apply properly!!! */
 
-@import url('https://refact0r.github.io/midnight-discord/midnight.css');
+/*
+links:
+prod: https://cdn.githubraw.com/refact0r/midnight-discord/master/midnight.css
+dev (faster reflected changes): https://githubraw.com/refact0r/midnight-discord/master/midnight.css
+*/
+
+@import url('https://cdn.githubraw.com/refact0r/midnight-discord/master/midnight.css');
 
 /* customize things here */
 :root {

--- a/flavors/midnight-catppuccin-frappe.theme.css
+++ b/flavors/midnight-catppuccin-frappe.theme.css
@@ -12,7 +12,13 @@
 
 /* IMPORTANT: make sure to enable dark mode in discord settings for the theme to apply properly!!! */
 
-@import url('https://refact0r.github.io/midnight-discord/midnight.css');
+/*
+links:
+prod: https://cdn.githubraw.com/refact0r/midnight-discord/master/midnight.css
+dev (faster reflected changes): https://githubraw.com/refact0r/midnight-discord/master/midnight.css
+*/
+
+@import url('https://cdn.githubraw.com/refact0r/midnight-discord/master/midnight.css');
 
 /* customize things here */
 :root {

--- a/flavors/midnight-catppuccin-macchiato.theme.css
+++ b/flavors/midnight-catppuccin-macchiato.theme.css
@@ -12,7 +12,13 @@
 
 /* IMPORTANT: make sure to enable dark mode in discord settings for the theme to apply properly!!! */
 
-@import url('https://refact0r.github.io/midnight-discord/midnight.css');
+/*
+links:
+prod: https://cdn.githubraw.com/refact0r/midnight-discord/master/midnight.css
+dev (faster reflected changes): https://githubraw.com/refact0r/midnight-discord/master/midnight.css
+*/
+
+@import url('https://cdn.githubraw.com/refact0r/midnight-discord/master/midnight.css');
 
 /* customize things here */
 :root {

--- a/flavors/midnight-catppuccin-mocha.theme.css
+++ b/flavors/midnight-catppuccin-mocha.theme.css
@@ -12,7 +12,13 @@
 
 /* IMPORTANT: make sure to enable dark mode in discord settings for the theme to apply properly!!! */
 
-@import url('https://refact0r.github.io/midnight-discord/midnight.css');
+/*
+links:
+prod: https://cdn.githubraw.com/refact0r/midnight-discord/master/midnight.css
+dev (faster reflected changes): https://githubraw.com/refact0r/midnight-discord/master/midnight.css
+*/
+
+@import url('https://cdn.githubraw.com/refact0r/midnight-discord/master/midnight.css');
 
 /* customize things here */
 :root {

--- a/flavors/midnight-night-owl.theme.css
+++ b/flavors/midnight-night-owl.theme.css
@@ -12,7 +12,13 @@
 
 /* IMPORTANT: make sure to enable dark mode in discord settings for the theme to apply properly!!! */
 
-@import url('https://refact0r.github.io/midnight-discord/midnight.css');
+/*
+links:
+prod: https://cdn.githubraw.com/refact0r/midnight-discord/master/midnight.css
+dev (faster reflected changes): https://githubraw.com/refact0r/midnight-discord/master/midnight.css
+*/
+
+@import url('https://cdn.githubraw.com/refact0r/midnight-discord/master/midnight.css');
 
 /* customize things here */
 :root {

--- a/flavors/midnight-nord.theme.css
+++ b/flavors/midnight-nord.theme.css
@@ -12,7 +12,13 @@
 
 /* IMPORTANT: make sure to enable dark mode in discord settings for the theme to apply properly!!! */
 
-@import url('https://refact0r.github.io/midnight-discord/midnight.css');
+/*
+links:
+prod: https://cdn.githubraw.com/refact0r/midnight-discord/master/midnight.css
+dev (faster reflected changes): https://githubraw.com/refact0r/midnight-discord/master/midnight.css
+*/
+
+@import url('https://cdn.githubraw.com/refact0r/midnight-discord/master/midnight.css');
 
 /* customize things here */
 :root {

--- a/flavors/midnight-pichu.theme.css
+++ b/flavors/midnight-pichu.theme.css
@@ -12,7 +12,13 @@
 
 /* IMPORTANT: make sure to enable dark mode in discord settings for the theme to apply properly!!! */
 
-@import url('https://refact0r.github.io/midnight-discord/midnight.css');
+/*
+links:
+prod: https://cdn.githubraw.com/refact0r/midnight-discord/master/midnight.css
+dev (faster reflected changes): https://githubraw.com/refact0r/midnight-discord/master/midnight.css
+*/
+
+@import url('https://cdn.githubraw.com/refact0r/midnight-discord/master/midnight.css');
 
 @import url('https://fonts.googleapis.com/css2?family=Nunito:ital,wght@0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;0,1000;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900;1,1000&display=swap');
 

--- a/flavors/midnight-rose-pine.theme.css
+++ b/flavors/midnight-rose-pine.theme.css
@@ -12,7 +12,13 @@
 
 /* IMPORTANT: make sure to enable dark mode in discord settings for the theme to apply properly!!! */
 
-@import url('https://refact0r.github.io/midnight-discord/midnight.css');
+/*
+links:
+prod: https://cdn.githubraw.com/refact0r/midnight-discord/master/midnight.css
+dev (faster reflected changes): https://githubraw.com/refact0r/midnight-discord/master/midnight.css
+*/
+
+@import url('https://cdn.githubraw.com/refact0r/midnight-discord/master/midnight.css');
 
 /* customize things here */
 :root {

--- a/flavors/midnight-spotify.theme.css
+++ b/flavors/midnight-spotify.theme.css
@@ -12,7 +12,13 @@
 
 /* IMPORTANT: make sure to enable dark mode in discord settings for the theme to apply properly!!! */
 
-@import url('https://refact0r.github.io/midnight-discord/midnight.css');
+/*
+links:
+prod: https://cdn.githubraw.com/refact0r/midnight-discord/master/midnight.css
+dev (faster reflected changes): https://githubraw.com/refact0r/midnight-discord/master/midnight.css
+*/
+
+@import url('https://cdn.githubraw.com/refact0r/midnight-discord/master/midnight.css');
 
 /* customize things here */
 :root {

--- a/flavors/midnight-vencord.theme.css
+++ b/flavors/midnight-vencord.theme.css
@@ -12,7 +12,13 @@
 
 /* IMPORTANT: make sure to enable dark mode in discord settings for the theme to apply properly!!! */
 
-@import url('https://refact0r.github.io/midnight-discord/midnight.css');
+/*
+links:
+prod: https://cdn.githubraw.com/refact0r/midnight-discord/master/midnight.css
+dev (faster reflected changes): https://githubraw.com/refact0r/midnight-discord/master/midnight.css
+*/
+
+@import url('https://cdn.githubraw.com/refact0r/midnight-discord/master/midnight.css');
 
 @import url('https://fonts.googleapis.com/css?family=Inter');
 

--- a/midnight.theme.css
+++ b/midnight.theme.css
@@ -12,7 +12,13 @@
 
 /* IMPORTANT: make sure to enable dark mode in discord settings for the theme to apply properly!!! */
 
-@import url('https://refact0r.github.io/midnight-discord/midnight.css');
+/*
+links:
+prod: https://cdn.githubraw.com/refact0r/midnight-discord/master/midnight.css
+dev (faster reflected changes): https://githubraw.com/refact0r/midnight-discord/master/midnight.css
+*/
+
+@import url('https://cdn.githubraw.com/refact0r/midnight-discord/master/midnight.css');
 
 /* customize things here */
 :root {

--- a/midnight.user.css
+++ b/midnight.user.css
@@ -14,7 +14,13 @@
 
 /* IMPORTANT: make sure to enable dark mode in discord settings for the theme to apply properly!!! */
 
-@import url('https://refact0r.github.io/midnight-discord/midnight.css');
+/*
+links:
+prod: https://cdn.githubraw.com/refact0r/midnight-discord/master/midnight.css
+dev (faster reflected changes): https://githubraw.com/refact0r/midnight-discord/master/midnight.css
+*/
+
+@import url('https://cdn.githubraw.com/refact0r/midnight-discord/master/midnight.css');
 
 /* customize things here */
 :root {


### PR DESCRIPTION
note: githubraw.com isn't the same as raw.githubusercontent.com.
it mirrors GitHub raw pages automatically, and adds the correct `Content-Type` header to the links so CSS can parse the data from the CSS file