### PR TITLE
Issue fixes & style change

### DIFF
--- a/midnight.css
+++ b/midnight.css
@@ -903,6 +903,11 @@ button.button_f67531 /* make user panel buttons round */ {
 	
 }
 
+/* Call padding */
+.wrapper_d880dc.normal_d880dc {
+	padding-bottom: var(--spacing);
+}
+
 /* change own profile hover to match border roundness */
 .avatarWrapper_b2ca13:hover {
 	border-radius: var(--roundness-xl);

--- a/midnight.css
+++ b/midnight.css
@@ -394,7 +394,7 @@ svg[fill='#593695'] {
 	background: var(--background-primary);
 	width: 100%;
 	height: 48px;
-	border-radius: var(--roundness-xl);
+	border-radius: var(--roundness-xl) var(--roundness-xl) 0 0;
 }
 .wrapper_d880dc.minimum_d880dc ~ .content_a7d72e .container__93316::before /* remove when in private call */ {
 	display: none;
@@ -492,7 +492,7 @@ a[href="https://support.discord.com"] /* hide help */
 .userPanelOuter_c69a7b /* profile panel inner */,
 .userPanelInner_c69a7b /* profile panel inner inner */,
 .userPanelInner_c69a7b::before /* profile panel inner inner filter */,
-.container_a6d69a /* forums */ {border-radius: var(--roundness-xl);}
+.container_a6d69a /* forums */ {border-radius: 0 0 var(--roundness-xl) var(--roundness-xl);}
 
 /* more rounded corners */
 .messagesPopoutWrap_ac90a2 /* inbox, pinned messages popout */,
@@ -610,9 +610,8 @@ button.button_dd4f85 /* small buttons */,
 }
 
 /* fix member list rounded corners */
-.members_cbd271 {
-	margin-top: var(--spacing);
-	border-radius: var(--roundness-xl);
+.members_cbd271.thin_c49869 {
+	border-radius: 0 0 var(--roundness-xl) var(--roundness-xl);
 }
 
 .guilds_a4d4d9::after /* add bottom scroll shadow */,
@@ -893,8 +892,6 @@ button.button_f67531 /* make user panel buttons round */ {
 	overflow: scroll !important;
 }
 
-/* New style */
-
 /* Call background fits theme */
 .callContainer_d880dc {
 	background: var(--bg-4);
@@ -904,29 +901,6 @@ button.button_f67531 /* make user panel buttons round */ {
 .gradientContainer_dd069c {
 	visibility: hidden;
 	
-}
-
-/* Margin the chat to fit the new theme*/
-.chatContent_a7d72e {
-	margin-top: var(--spacing)
-}
-
-/* Margin the chat header to stay in line with search */
-.chatContent_a7d72e::before {
-	margin-top: calc(-48px - var(--spacing));
-}
-
-/* Fix chat search placement */
-.searchResultsWrap_c2b47d {
-	margin-top: var(--spacing);
-}
-.searchResultsWrap_c2b47d::before {
-	margin-top: calc(-48px - var(--spacing));
-}
-
-/* Fix chat search roundness */
-.searchHeader_b7c924 {
-	border-radius: var(--roundness-xl) var(--roundness-xl) 0 0;
 }
 
 /* change own profile hover to match border roundness */

--- a/midnight.css
+++ b/midnight.css
@@ -899,6 +899,18 @@ button.button_f67531 /* make user panel buttons round */ {
 	overflow: scroll !important;
 }
 
+.wrapper_d880dc.normal_d880dc {
+	padding-bottom: var(--spacing);
+}
+
+.callContainer_d880dc {
+	border-radius: var(--roundness-xl) var(--roundness-xl) 0 0 !important;
+	background: var(--bg-4);
+}
+
+.gradientContainer_dd069c {
+	visibility: hidden;
+}
 .theme-light {
 	--text-link: var(--accent-5);
 }

--- a/midnight.css
+++ b/midnight.css
@@ -926,6 +926,14 @@ button.button_f67531 /* make user panel buttons round */ {
 	border-radius: var(--roundness-xl);
 }
 
+/* fix scrollbars so bg-2 is not default for thin */
+.content_b56bbc .thin_eed6a8::-webkit-scrollbar-thumb,
+.wrapper_de4721 .thin_c49869::-webkit-scrollbar-thumb,
+.listWrapper_a3bc57 .thin_c49869::-webkit-scrollbar-thumb
+{
+	background-color: var(--bg-2);
+}
+
 .theme-light {
 	--text-link: var(--accent-5);
 }
@@ -1176,7 +1184,7 @@ html.theme-light,
 	--scrollbar-auto-scrollbar-color-track: var(--primary-630);
 	--scrollbar-auto-thumb: var(--bg-3);
 	--scrollbar-auto-track: transparent;
-	--scrollbar-thin-thumb: var(--bg-2);
+	--scrollbar-thin-thumb: var(--bg-3);
 	--scrollbar-thin-track: transparent;
 	--__spoiler-background-color--hidden: var(--bg-2);
 	--__spoiler-background-color--hidden--hover: var(--hover);

--- a/midnight.css
+++ b/midnight.css
@@ -812,11 +812,6 @@ button.button_dd4f85 /* small buttons */,
 	margin-left: 4px;
 }
 
-/* horizontal server list fix */
-#app-mount .app_bd26cc .base_a4d4d9 {
-	top: calc(var(--server-container) + var(--spacing)) !important;
-}
-
 /* list hover animations */
 .wrapper_d8bfb3 .link_d8bfb3 /* channels */,
 .container_e9f61e /* members */,

--- a/midnight.css
+++ b/midnight.css
@@ -894,6 +894,7 @@ button.button_f67531 /* make user panel buttons round */ {
 
 /* Call background fits theme */
 .callContainer_d880dc {
+	border-radius: var(--roundness-xl) var(--roundness-xl) 0 0 !important;
 	background: var(--bg-4);
 }
 

--- a/midnight.css
+++ b/midnight.css
@@ -916,6 +916,19 @@ button.button_f67531 /* make user panel buttons round */ {
 	margin-top: calc(-48px - var(--spacing));
 }
 
+/* Fix chat search placement */
+.searchResultsWrap_c2b47d {
+	margin-top: var(--spacing);
+}
+.searchResultsWrap_c2b47d::before {
+	margin-top: calc(-48px - var(--spacing));
+}
+
+/* Fix chat search roundness */
+.searchHeader_b7c924 {
+	border-radius: var(--roundness-xl) var(--roundness-xl) 0 0;
+}
+
 /* change own profile hover to match border roundness */
 .avatarWrapper_b2ca13:hover {
 	border-radius: var(--roundness-xl);

--- a/midnight.css
+++ b/midnight.css
@@ -926,7 +926,7 @@ button.button_f67531 /* make user panel buttons round */ {
 	border-radius: var(--roundness-xl);
 }
 
-/* fix scrollbars so bg-2 is not default for thin */
+/* fix scrollbars in emotes menu */
 .content_b56bbc .thin_eed6a8::-webkit-scrollbar-thumb,
 .wrapper_de4721 .thin_c49869::-webkit-scrollbar-thumb,
 .listWrapper_a3bc57 .thin_c49869::-webkit-scrollbar-thumb

--- a/midnight.css
+++ b/midnight.css
@@ -921,6 +921,11 @@ button.button_f67531 /* make user panel buttons round */ {
 	margin-top: calc(-48px - var(--spacing));
 }
 
+/* change own profile hover to match border roundness */
+.avatarWrapper_b2ca13:hover {
+	border-radius: var(--roundness-xl);
+}
+
 .theme-light {
 	--text-link: var(--accent-5);
 }

--- a/midnight.css
+++ b/midnight.css
@@ -1161,7 +1161,7 @@ html.theme-light,
 	--scrollbar-auto-scrollbar-color-track: var(--primary-630);
 	--scrollbar-auto-thumb: var(--bg-3);
 	--scrollbar-auto-track: transparent;
-	--scrollbar-thin-thumb: var(--bg-3);
+	--scrollbar-thin-thumb: var(--bg-2);
 	--scrollbar-thin-track: transparent;
 	--__spoiler-background-color--hidden: var(--bg-2);
 	--__spoiler-background-color--hidden--hover: var(--hover);

--- a/midnight.css
+++ b/midnight.css
@@ -942,6 +942,14 @@ button.button_f67531 /* make user panel buttons round */ {
 	background-color: var(--bg-2);
 }
 
+/* fix discovery icon */
+.footer_aa1bff {
+	background: unset;
+}
+.fixedDiscoveryIcon_fea3ef {
+	color:var(--green-360)
+}
+
 .theme-light {
 	--text-link: var(--accent-5);
 }

--- a/midnight.css
+++ b/midnight.css
@@ -924,7 +924,7 @@ button.button_f67531 /* make user panel buttons round */ {
 
 /* fix discovery icon */
 .footer_aa1bff {
-	background: unset;
+	background: var(--bg-overlay-app-frame,var(--bg-4));
 }
 .fixedDiscoveryIcon_fea3ef {
 	color:var(--green-360)

--- a/midnight.css
+++ b/midnight.css
@@ -394,7 +394,7 @@ svg[fill='#593695'] {
 	background: var(--background-primary);
 	width: 100%;
 	height: 48px;
-	border-radius: var(--roundness-xl) var(--roundness-xl) 0 0;
+	border-radius: var(--roundness-xl);
 }
 .wrapper_d880dc.minimum_d880dc ~ .content_a7d72e .container__93316::before /* remove when in private call */ {
 	display: none;
@@ -492,9 +492,7 @@ a[href="https://support.discord.com"] /* hide help */
 .userPanelOuter_c69a7b /* profile panel inner */,
 .userPanelInner_c69a7b /* profile panel inner inner */,
 .userPanelInner_c69a7b::before /* profile panel inner inner filter */,
-.container_a6d69a /* forums */ {
-	border-radius: 0 0 var(--roundness-xl) var(--roundness-xl);
-}
+.container_a6d69a /* forums */ {border-radius: var(--roundness-xl);}
 
 /* more rounded corners */
 .messagesPopoutWrap_ac90a2 /* inbox, pinned messages popout */,
@@ -613,7 +611,8 @@ button.button_dd4f85 /* small buttons */,
 
 /* fix member list rounded corners */
 .members_cbd271 {
-	border-radius: 0 0 var(--roundness-xl) var(--roundness-xl) !important;
+	margin-top: var(--spacing);
+	border-radius: var(--roundness-xl);
 }
 
 .guilds_a4d4d9::after /* add bottom scroll shadow */,
@@ -899,18 +898,29 @@ button.button_f67531 /* make user panel buttons round */ {
 	overflow: scroll !important;
 }
 
-.wrapper_d880dc.normal_d880dc {
-	padding-bottom: var(--spacing);
-}
+/* New style */
 
+/* Call background fits theme */
 .callContainer_d880dc {
-	border-radius: var(--roundness-xl) var(--roundness-xl) 0 0 !important;
 	background: var(--bg-4);
 }
 
+/* Remove gradient from call containers */
 .gradientContainer_dd069c {
 	visibility: hidden;
+	
 }
+
+/* Margin the chat to fit the new theme*/
+.chatContent_a7d72e {
+	margin-top: var(--spacing)
+}
+
+/* Margin the chat header to stay in line with search */
+.chatContent_a7d72e::before {
+	margin-top: calc(-48px - var(--spacing));
+}
+
 .theme-light {
 	--text-link: var(--accent-5);
 }


### PR DESCRIPTION
Solves:
- #101 (I HIGHLY RECOMMEND READING THIS BEFORE CONSIDERING A MERGE)

Changes:
- Seperated title header and search header from the chat area (makes it work with calls)
- Removed the black call background and gradient to match the rest of the themes
- Rounded call corners and added spacing
- Fix the new discovery icon to be consistent with the theme
- Change the scrollbar color in the emotes menu to bg-2 so it's visible