### PR TITLE
fix user panel gets longer than channels list

### DIFF
--- a/build/midnight.css
+++ b/build/midnight.css
@@ -1344,6 +1344,9 @@ body {
                 'guildsList channelsList page'
                 'guildsList userPanel page';
         }
+        .panels_c48ade {
+            max-width: calc(var(--custom-guild-sidebar-width) - var(--custom-guild-list-width));
+        }
     }
 }
 

--- a/src/user-panel.css
+++ b/src/user-panel.css
@@ -13,5 +13,8 @@
                 'guildsList channelsList page'
                 'guildsList userPanel page';
         }
+        .panels_c48ade {
+            max-width: calc(var(--custom-guild-sidebar-width) - var(--custom-guild-list-width));
+        }
     }
 }


### PR DESCRIPTION
I'm not sure if I did right, please check.

user panel gets longer than channels list when small-user-panel is on and spotifycontrol has long text so I made it match to channels list if small-user-panel is on.