### PR TITLE
Fix gc participants not being aligned in the center

### DIFF
--- a/build/midnight.css
+++ b/build/midnight.css
@@ -233,6 +233,11 @@ body {
         background: none;
     }
 
+    .root_bfe55a > div:first-child {
+        align-items: center;
+        justify-content: center;
+    }
+
     .page_c48ade > div > .chatLayerWrapper__01ae2 /* forum/thread chat outer */ {
         margin: 0 var(--gap) var(--gap) 0;
         height: calc(100% - var(--gap));


### PR DESCRIPTION
### Before:
![image](https://github.com/user-attachments/assets/f51387fd-e571-485b-ace8-687b4903363c)

---
### After:
![image](https://github.com/user-attachments/assets/71025625-4e17-4354-bee4-22eb3e025b67)
