### PR TITLE
fix dm user panel and profile card gradient overflows

### DIFF
--- a/src/main.css
+++ b/src/main.css
@@ -233,6 +233,8 @@ body {
         overflow: hidden;
         height: auto;
         min-width: 340px;
+        background-position: center calc(-1 * var(--border-thickness));
+        background-size: 100% calc(100% + 2 * var(--border-thickness));
     }
 
     .searchResultsWrap_a9e706 /* search results */ {
@@ -411,6 +413,8 @@ body {
     .outer_c0bea0 /* profile outer */, 
     .contentWrapper__08434  /* gif panel */ {
         border-radius: var(--radius-lg);
+        background-position: center calc(-1 * var(--border-thickness));
+        background-size: 100% calc(100% + 2 * var(--border-thickness));
     }
     .inner_c0bea0 /* profile inner */ {
         border-radius: calc(var(--radius-lg) - 4px);


### PR DESCRIPTION

![issue](https://github.com/user-attachments/assets/16369bbb-0688-4b21-beab-a0acbda12a7f)

as shown on the image the gradient for the border starts to repeat at the top and the bottom

this detail is visible on every user popup/card thingy where the gradients are present including the user profile sidebar in dms

for the picture i used the system24 theme because the error is more visible with that, but it can also be seen on midnight, its just way more subtle 

my css skills are not the greatest but i found a fix for them by expanding and displacing the background