### PR TITLE
fix: changed moon icon link in `dms-button.css`

### DIFF
--- a/src/dms-button.css
+++ b/src/dms-button.css
@@ -1,5 +1,5 @@
 body {
-    --dms-icon-svg-url: url('https://upload.wikimedia.org/wikipedia/commons/c/c4/Font_Awesome_5_solid_moon.svg'); /* icon svg url. MUST BE A SVG. */
+    --dms-icon-svg-url: url('https://refact0r.github.io/midnight-discord/assets/Font_Awesome_5_solid_moon.svg'); /* icon svg url. MUST BE A SVG. */
     --dms-icon-svg-size: 90%; /* size of the svg (css mask-size property) */
     --dms-icon-color-before: var(--icon-secondary); /* normal icon color */
     --dms-icon-color-after: var(--white); /* icon color when button is hovered/selected */


### PR DESCRIPTION
After some of the recent changes with the moon icon, this file seems to have been missed and whoever uses the url instead of downloading the file did not get the fix.

This PR should fix this issue since the build seems to be using the `dms-button.css` file.

Partly Resolves: https://github.com/refact0r/midnight-discord/issues/293 (Still needs changing on flavors)