### PR TITLE
Fix chatbox elements overflow

### DIFF
--- a/src/main.css
+++ b/src/main.css
@@ -133,6 +133,9 @@ body {
         border: none !important;
         background: none;
     }
+    .chatContent_f75fb0 {
+        overflow: hidden;
+    }
     .container__133bf /* friends page group outer */,
     .page_c48ade {
         padding-bottom: var(--gap);


### PR DESCRIPTION
A small css-rule to prevent elements from overflowing the chatbox in server / direct messages.

[ See before and after ]
![Discord_qe4mJWQaVd](https://github.com/user-attachments/assets/5790dafd-bbf9-4468-b20f-7ef2bd4b1ff5)
![Discord_0breKdiM2F](https://github.com/user-attachments/assets/9027faa2-c3df-4131-b8a1-a2095dba5552)
