### PR TITLE
chore: update user-panel classes

### DIFF
--- a/build/midnight.css
+++ b/build/midnight.css
@@ -1853,12 +1853,16 @@ body {
 
 @container body style(--small-user-panel: on) {
     .visual-refresh {
-        .panels_c48ade /* user panel */ {
+
+        /* user panel */
+        .panels__5e434 {
             right: 0;
             left: unset;
             width: calc(var(--custom-guild-sidebar-width) - var(--custom-guild-list-width));
         }
-        .guilds_c48ade /* server list */ {
+
+        /* server list */
+        .guilds__5e434 {
             margin-bottom: 0;
         }
     }

--- a/src/user-panel.css
+++ b/src/user-panel.css
@@ -6,12 +6,16 @@
 
 @container body style(--small-user-panel: on) {
     .visual-refresh {
-        .panels_c48ade /* user panel */ {
+
+        /* user panel */
+        .panels__5e434 {
             right: 0;
             left: unset;
             width: calc(var(--custom-guild-sidebar-width) - var(--custom-guild-list-width));
         }
-        .guilds_c48ade /* server list */ {
+
+        /* server list */
+        .guilds__5e434 {
             margin-bottom: 0;
         }
     }


### PR DESCRIPTION
the class updater only updated `src/main.css` and not the other css modules, so the `--small-user-panel` option broke