### PR TITLE
Fix black name when using name customization

### DIFF
--- a/build/midnight.css
+++ b/build/midnight.css
@@ -937,7 +937,7 @@ body {
         --scrollbar-thin-track: transparent;
 
         --white: var(--text-0);
-        --white-500: var(--text-4);
+        --white-500: var(--text-3);
         --redesign-button-overlay-alpha-text: var(--text-2);
 
         --brand-360: var(--accent-2);

--- a/src/colors.css
+++ b/src/colors.css
@@ -304,7 +304,7 @@
         --scrollbar-thin-track: transparent;
 
         --white: var(--text-0);
-        --white-500: var(--text-4);
+        --white-500: var(--text-3);
         --redesign-button-overlay-alpha-text: var(--text-2);
 
         --brand-360: var(--accent-2);


### PR DESCRIPTION
I am not sure where this variable is being used outside of the customized names. From a brief look into the source files I saw it was referenced several times. If you know of spots that it actually shows up, please let me know.