### PR TITLE
Change notice positive color to default (green)

### DIFF
--- a/build/midnight.css
+++ b/build/midnight.css
@@ -1035,7 +1035,7 @@ body {
         --notice-background-warning: yellow;
         --notice-text-critical: lime;
         --notice-text-info: blue;
-        --notice-text-positive: magenta;
+        --notice-text-positive: var(--green-new-14);
         --notice-text-warning: red;
         --overlay-backdrop-lightbox: yellow;
         --panel-bg: lime;


### PR DESCRIPTION
bring back notice positive default green instead of red and magenta

<img width="1272" height="41" alt="image" src="https://github.com/user-attachments/assets/5561802c-a6f7-4052-ae67-4c0068e372a3" />
