### PR TITLE
Background blur for context menus

### DIFF
--- a/build/midnight.css
+++ b/build/midnight.css
@@ -1943,6 +1943,16 @@ body {
         .bar__7aaec /* channel list new unreads bar */ {
         background: var(--bg-floating);
     }
+
+    .menu_c1e9c4::before {
+        content: '';
+        position: absolute;
+        backdrop-filter: var(--panel-backdrop-filter);
+        border-radius: 8px;
+        background: transparent;
+        width: 100%;
+        height: 100%;
+    }
 }
 
 @property --transparency-tweaks {

--- a/src/transparency-blur.css
+++ b/src/transparency-blur.css
@@ -24,6 +24,24 @@
         .bar__7aaec /* channel list new unreads bar */ {
         background: var(--bg-floating);
     }
+
+    .menu_c1e9c4::before {
+        position: absolute;
+        backdrop-filter: var(--panel-backdrop-filter);
+        border-radius: 8px;
+        background: transparent;
+        width: 100%;
+        height: 100%;
+        content: " ";
+    }
+
+    .submenuPaddingContainer_c1e9c4 > .menu_c1e9c4::before {
+        width: calc(100% - 16px);
+    }
+
+    .submenuPaddingContainer_ce8328 > .menu_c1e9c4::before {
+        width: calc(100% - 24px);
+    }
 }
 
 @property --transparency-tweaks {

--- a/src/transparency-blur.css
+++ b/src/transparency-blur.css
@@ -26,21 +26,13 @@
     }
 
     .menu_c1e9c4::before {
+        content: '';
         position: absolute;
         backdrop-filter: var(--panel-backdrop-filter);
         border-radius: 8px;
         background: transparent;
         width: 100%;
         height: 100%;
-        content: " ";
-    }
-
-    .submenuPaddingContainer_c1e9c4 > .menu_c1e9c4::before {
-        width: calc(100% - 16px);
-    }
-
-    .submenuPaddingContainer_ce8328 > .menu_c1e9c4::before {
-        width: calc(100% - 24px);
     }
 }
 


### PR DESCRIPTION
Added backdrop filter and styling for menu elements.
This is done using the `::before` pseudo element since applying the backdrop filter directly would alter positioning. Paddings of submenus needed to be hardcoded.
Fixes #267 and #227 partially, because it isn't a seperate option (although one could be added).