### PR TITLE
Adjust padding for user panel and action buttons

### DIFF
--- a/src/user-panel.css
+++ b/src/user-panel.css
@@ -8,8 +8,15 @@
     ._5e434347c823b592-panels /* user panel */ {
         right: 0;
         left: unset;
+        padding-top: 10px !important;
         width: calc(var(--custom-guild-sidebar-width) - var(--custom-guild-list-width));
     }
+
+    .e131a99484292a19-actionButtons {
+        padding-top: 15px !important;
+        padding-bottom: 5px !important;
+    }
+
     ._5e434347c823b592-guilds /* server list */ {
         margin-bottom: 0;
     }


### PR DESCRIPTION
Added padding to user panel and action buttons, fixing the `Voice Connected` text.

Referenced at #401 

<img width="358" height="59" alt="image" src="https://github.com/user-attachments/assets/090e448d-7894-4dce-a3a1-386308f027a8" />
