### PR TITLE
Fix code block text color

### DIFF
--- a/build/midnight.css
+++ b/build/midnight.css
@@ -757,6 +757,7 @@ body {
     --text-3: hsl(220, 20%, 60%); /* normal text */
     --text-4: hsl(220, 15%, 40%); /* icon buttons and channels */
     --text-5: hsl(220, 15%, 25%); /* muted channels/chats and timestamps */
+    --text-code: hsl(220, 20%, 55%); /* text inside code blocks */
 
     /* background and dark colors */
     --bg-1: hsla(220, 15%, 20%, 1); /* dark buttons when clicked */

--- a/src/colors.css
+++ b/src/colors.css
@@ -12,6 +12,7 @@
     --text-3: hsl(220, 20%, 60%); /* normal text */
     --text-4: hsl(220, 15%, 40%); /* icon buttons and channels */
     --text-5: hsl(220, 15%, 25%); /* muted channels/chats and timestamps */
+    --text-code: hsl(220, 20%, 55%); /* text inside code blocks */
 
     /* background and dark colors */
     --bg-1: hsla(220, 15%, 20%, 1); /* dark buttons when clicked */

--- a/test/colors-old.css
+++ b/test/colors-old.css
@@ -12,6 +12,7 @@
     --text-3: hsl(220, 20%, 60%); /* normal text */
     --text-4: hsl(220, 15%, 40%); /* icon buttons and channels */
     --text-5: hsl(220, 15%, 25%); /* muted channels/chats and timestamps */
+    --text-code: hsl(220, 20%, 55%); /* text inside code blocks */
 
     /* background and dark colors */
     --bg-1: hsl(220, 15%, 20%); /* dark buttons when clicked */

--- a/test/system24-test.css
+++ b/test/system24-test.css
@@ -82,6 +82,7 @@ body {
     --text-3: oklch(75% 0 0); /* normal text */
     --text-4: oklch(60% 0 0); /* icon buttons and channels */
     --text-5: oklch(40% 0 0); /* muted channels/chats and timestamps */
+    --text-code: oklch(70% 0 0); /* text inside code blocks */
 
     /* background and dark colors */
     --bg-1: oklch(31% 0 0); /* dark buttons when clicked */

--- a/themes/flavors/midnight-auto.theme.css
+++ b/themes/flavors/midnight-auto.theme.css
@@ -83,6 +83,7 @@ body {
     --text-3: hsl(220, 20%, 60%); /* normal text */
     --text-4: hsl(220, 15%, 40%); /* icon buttons and channels */
     --text-5: hsl(220, 15%, 25%); /* muted channels/chats and timestamps */
+    --text-code: hsl(220, 20%, 55%); /* text inside code blocks */
 
     /* background and dark colors */
     --bg-1: hsla(220, 15%, 20%, 1); /* dark buttons when clicked */
@@ -163,6 +164,7 @@ body {
         --text-3: hsl(220, 15%, 20%);
         --text-4: hsl(220, 15%, 40%);
         --text-5: hsl(220, 20%, 60%);
+        --text-code: hsl(220, 15%, 25%);
 
         /* background and light colors */
         --bg-1: hsla(220, 30%, 81%, 1);

--- a/themes/flavors/midnight-background.theme.css
+++ b/themes/flavors/midnight-background.theme.css
@@ -82,6 +82,7 @@ body {
     --text-3: hsl(220, 20%, 70%); /* normal text */
     --text-4: hsl(220, 15%, 50%); /* icon buttons and channels */
     --text-5: hsl(220, 15%, 35%); /* muted channels/chats and timestamps */
+    --text-code: hsl(220, 20%, 65%); /* text inside code blocks */
 
     /* background and dark colors */
     --bg-1: hsla(220, 15%, 20%, 0.6); /* dark buttons when clicked */

--- a/themes/flavors/midnight-catppuccin-macchiato.theme.css
+++ b/themes/flavors/midnight-catppuccin-macchiato.theme.css
@@ -82,6 +82,7 @@ body {
     --text-3: #b8c0e0; /* normal text */
     --text-4: #8087a2; /* icon buttons and channels */
     --text-5: #5b6078; /* muted channels/chats and timestamps */
+    --text-code: #a6b0d8; /* text inside code blocks */
 
     /* background and dark colors */
     --bg-1: #494d64; /* dark buttons when clicked */

--- a/themes/flavors/midnight-catppuccin-mocha.theme.css
+++ b/themes/flavors/midnight-catppuccin-mocha.theme.css
@@ -82,6 +82,7 @@ body {
     --text-3: #bac2de; /* normal text */
     --text-4: #7f849c; /* icon buttons and channels */
     --text-5: #585b70; /* muted channels/chats and timestamps */
+    --text-code: #a9b2d6; /* text inside code blocks */
 
     /* background and dark colors */
     --bg-1: #45475a; /* dark buttons when clicked */

--- a/themes/flavors/midnight-light.theme.css
+++ b/themes/flavors/midnight-light.theme.css
@@ -83,6 +83,7 @@ body {
     --text-3: hsl(220, 15%, 20%); /* normal text */
     --text-4: hsl(220, 15%, 40%); /* icon buttons and channels */
     --text-5: hsl(220, 20%, 60%); /* muted channels/chats and timestamps */
+    --text-code: hsl(220, 15%, 25%); /* text inside code blocks */
 
     /* background and light colors */
     --bg-1: hsla(220, 30%, 81%, 1); /* dark buttons when clicked */

--- a/themes/flavors/midnight-lilypichu.theme.css
+++ b/themes/flavors/midnight-lilypichu.theme.css
@@ -83,6 +83,7 @@ body {
     --text-3: hsl(348, 48%, 88%); /* normal text */
     --text-4: hsl(347, 40%, 68%); /* icon buttons and channels */
     --text-5: hsl(346, 32%, 45%); /* muted channels/chats and timestamps */
+    --text-code: hsl(348, 48%, 83%); /* text inside code blocks */
 
     /* background and dark colors */
     --bg-1: hsl(337, 27%, 43%); /* dark buttons when clicked */

--- a/themes/flavors/midnight-nord.theme.css
+++ b/themes/flavors/midnight-nord.theme.css
@@ -82,6 +82,7 @@ body {
     --text-3: #d8dee9; /* normal text */
     --text-4: hsl(220, 20%, 67%); /* icon buttons and channels */
     --text-5: #4c566a; /* muted channels/chats and timestamps */
+    --text-code: #c8d0e0; /* text inside code blocks */
 
     /* background and dark colors */
     --bg-1: #434c5e; /* dark buttons when clicked */

--- a/themes/flavors/midnight-rose-pine-moon.theme.css
+++ b/themes/flavors/midnight-rose-pine-moon.theme.css
@@ -82,6 +82,7 @@ body {
     --text-3: hsl(246deg, 30%, 80%); /* normal text */
     --text-4: hsl(248deg, 15%, 61%); /* icon buttons and channels */
     --text-5: hsl(249deg, 12%, 47%); /* muted channels/chats and timestamps */
+    --text-code: hsl(246deg, 30%, 75%); /* text inside code blocks */
 
     /* background and dark colors */
     --bg-1: hsl(248deg, 21%, 32%); /* dark buttons when clicked */

--- a/themes/flavors/midnight-rose-pine.theme.css
+++ b/themes/flavors/midnight-rose-pine.theme.css
@@ -82,6 +82,7 @@ body {
     --text-3: hsl(246deg, 30%, 80%); /* normal text */
     --text-4: hsl(248deg, 15%, 61%); /* icon buttons and channels */
     --text-5: hsl(249deg, 12%, 47%); /* muted channels/chats and timestamps */
+    --text-code: hsl(246deg, 30%, 75%); /* text inside code blocks */
 
     /* background and dark colors */
     --bg-1: hsl(248deg, 25%, 24%); /* dark buttons when clicked */

--- a/themes/flavors/midnight-tokyo-night.theme.css
+++ b/themes/flavors/midnight-tokyo-night.theme.css
@@ -82,6 +82,7 @@ body {
     --text-3: #a9b1d6; /* normal text */
     --text-4: hsl(229, 21%, 54%); /* icon buttons and channels */
     --text-5: #414868; /* muted channels/chats and timestamps */
+    --text-code: #98a2ce; /* text inside code blocks */
 
     /* background and dark colors */
     --bg-1: hsl(230, 22%, 25%); /* dark buttons when clicked */

--- a/themes/flavors/midnight-vencord.theme.css
+++ b/themes/flavors/midnight-vencord.theme.css
@@ -83,6 +83,7 @@ body {
     --text-3: #d4be98; /* normal text */
     --text-4: #a79a83; /* icon buttons and channels */
     --text-5: #d4be9866; /* muted channels/chats and timestamps */
+    --text-code: #cdb386; /* text inside code blocks */
 
     /* background and dark colors */
     --bg-1: hsl(20, 5%, 25%); /* dark buttons when clicked */

--- a/themes/midnight.theme.css
+++ b/themes/midnight.theme.css
@@ -82,6 +82,7 @@ body {
     --text-3: hsl(220, 20%, 60%); /* normal text */
     --text-4: hsl(220, 15%, 40%); /* icon buttons and channels */
     --text-5: hsl(220, 15%, 25%); /* muted channels/chats and timestamps */
+    --text-code: hsl(220, 20%, 55%); /* text inside code blocks */
 
     /* background and dark colors */
     --bg-1: hsla(220, 15%, 20%, 1); /* dark buttons when clicked */


### PR DESCRIPTION
Adds `--text-code` to all themes. Dark themes decrease HSL lightness by 5%, light themes increase it by 5%, improving contrast against code block backgrounds. The 5% increase/decrease is similar to what Discord does by default.

Fixes #452

<img width="558" height="102" alt="image" src="https://github.com/user-attachments/assets/1e047966-7853-4a3b-b81a-966af61c8eae" />