### PR TITLE
fix context menu blur overflow

### DIFF
--- a/src/transparency-blur.css
+++ b/src/transparency-blur.css
@@ -34,6 +34,14 @@
         width: 100%;
         height: 100%;
     }
+
+    .submenuPaddingContainer_c1e9c4>.menu_c1e9c4::before {
+        width: calc(100% - 16px);
+    }
+
+    .submenuPaddingContainer_ce8328>.menu_c1e9c4::before {
+        width: calc(100% - 24px);
+    }
 }
 
 @property --transparency-tweaks {


### PR DESCRIPTION
Fixes the background blur overflowing the context menu. The class has not changed since #392 

|class|Before|After|
|---|---|---|
|`.submenuPaddingContainer_c1e9c4`|<img width="391" height="474" alt="image" src="https://github.com/user-attachments/assets/02db4b22-4bdc-4ee4-a1a3-2531b031d660" />|<img width="387" height="473" alt="image" src="https://github.com/user-attachments/assets/3fd63842-1748-4eff-a267-3eb37ece981a" />|
|`.submenuPaddingContainer_ce8328`|<img width="597" height="245" alt="image" src="https://github.com/user-attachments/assets/b4a322fc-0799-4d96-b2d4-acd7992f7e5a" />|<img width="573" height="245" alt="image" src="https://github.com/user-attachments/assets/75b0f923-b690-43d4-a78d-37734c83ce01" />|